### PR TITLE
correct path for pdf

### DIFF
--- a/leanblueprint/jekyll_templates/index.md
+++ b/leanblueprint/jekyll_templates/index.md
@@ -10,6 +10,6 @@ Useful links:
 
 * [Zulip chat for Lean](https://leanprover.zulipchat.com/) for coordination
 * [Blueprint]({{ site.url }}/blueprint/)
-* [Blueprint as pdf]({{ site.url }}/blueprint.pdf)
+* [Blueprint as pdf]({{ site.url }}/blueprint/blueprint.pdf)
 * [Dependency graph]({{ site.url }}/blueprint/dep_graph_document.html)
 * [Doc pages for this repository]({{ site.url }}/docs/)


### PR DESCRIPTION
I think this needs to be corrected, at least when trying out the blueprint here: 
https://firsching.ch/formal_book/
I needed to change the url.